### PR TITLE
from gym import error in soccer_empty_goal.py

### DIFF
--- a/gym_soccer/envs/soccer_empty_goal.py
+++ b/gym_soccer/envs/soccer_empty_goal.py
@@ -1,5 +1,6 @@
 import logging
 import math
+from gym import error
 from gym_soccer.envs.soccer_env import SoccerEnv
 
 try:


### PR DESCRIPTION
__error__ is used on line 9 but it is never imported.

flake8 testing of https://github.com/openai/gym-soccer on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./gym_soccer/envs/soccer_empty_goal.py:8:11: F821 undefined name 'error'
    raise error.DependencyNotInstalled("{}. (HINT: you can install HFO dependencies with 'pip install gym[soccer].)'".format(e))
          ^
1     F821 undefined name 'error'
1
```